### PR TITLE
[WIP] Some changes to Support schema postgres

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -59,8 +59,8 @@ return [
         // Tenant database managers handle the creation & deletion of tenant databases.
         'sqlite' => Stancl\Tenancy\TenantDatabaseManagers\SQLiteDatabaseManager::class,
         'mysql' => Stancl\Tenancy\TenantDatabaseManagers\MySQLDatabaseManager::class,
-        // 'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
-        'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
+        'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
+        // 'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
     ],
     'database_manager_connections' => [
         // Connections used by TenantDatabaseManagers. This tells, for example, the

--- a/assets/config.php
+++ b/assets/config.php
@@ -59,8 +59,8 @@ return [
         // Tenant database managers handle the creation & deletion of tenant databases.
         'sqlite' => Stancl\Tenancy\TenantDatabaseManagers\SQLiteDatabaseManager::class,
         'mysql' => Stancl\Tenancy\TenantDatabaseManagers\MySQLDatabaseManager::class,
-        'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
-        'schema' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLSchemaManager::class
+        // 'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
+        'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
     ],
     'database_manager_connections' => [
         // Connections used by TenantDatabaseManagers. This tells, for example, the
@@ -68,9 +68,8 @@ return [
         'sqlite' => 'sqlite',
         'mysql' => 'mysql',
         'pgsql' => 'pgsql',
-        'schema' => 'pgsql'
     ],
-    'using_schema_connection' => false, // Only work with pgsql connection
+    'separate_by' => 'database', // database or schema (only supported by pgsql)
     'bootstrappers' => [
         // Tenancy bootstrappers are executed when tenancy is initialized.
         // Their responsibility is making Laravel features tenant-aware.

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy;
 
 use Closure;
+use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\DatabaseManager as BaseDatabaseManager;
 use Illuminate\Foundation\Application;
@@ -100,12 +101,9 @@ class DatabaseManager
 
         // Change database name.
         $databaseName = $this->getDriver($connectionName) === 'sqlite' ? database_path($databaseName) : $databaseName;
+        $separateBy = $this->separateBy($connectionName);
 
-        if ($this->isUsingSchema($connectionName)) {
-            $this->app['config']["database.connections.$connectionName.schema"] = $databaseName;
-        } else {
-            $this->app['config']["database.connections.$connectionName.database"] = $databaseName;
-        }
+        $this->app['config']["database.connections.$connectionName.$separateBy"] = $databaseName;
     }
 
     /**
@@ -231,7 +229,7 @@ class DatabaseManager
      */
     public function getTenantDatabaseManager(Tenant $tenant): TenantDatabaseManager
     {
-        $driver = $this->isUsingSchema($tenant->getConnectionName()) ? 'schema' : $this->getDriver($this->getBaseConnection($tenant->getConnectionName()));
+        $driver = $this->getDriver($this->getBaseConnection($tenant->getConnectionName()));
 
         $databaseManagers = $this->app['config']['tenancy.database_managers'];
 
@@ -243,13 +241,18 @@ class DatabaseManager
     }
     
     /**
-     * Check if using schema connection
+     * What key on the connection config should be used to separate tenants.
      * 
      * @param string $connectionName
-     * @return bool
+     * @return string
      */
-    protected function isUsingSchema(string $connectionName): bool
+    public function separateBy(string $connectionName): string
     {
-        return $this->getDriver($this->getBaseConnection($connectionName)) === 'pgsql' && $this->app['config']['tenancy.using_schema_connection'];
+        if ($this->getDriver($this->getBaseConnection($connectionName)) === 'pgsql'
+            && $this->app['config']['tenancy.separate_by'] === 'schema') {
+                return 'schema';
+        }
+
+        return 'database';
     }
 }

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Stancl\Tenancy;
 
 use Closure;
-use Exception;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\DatabaseManager as BaseDatabaseManager;
 use Illuminate\Foundation\Application;
@@ -239,10 +238,10 @@ class DatabaseManager
 
         return $this->app[$databaseManagers[$driver]];
     }
-    
+
     /**
      * What key on the connection config should be used to separate tenants.
-     * 
+     *
      * @param string $connectionName
      * @return string
      */
@@ -250,7 +249,7 @@ class DatabaseManager
     {
         if ($this->getDriver($this->getBaseConnection($connectionName)) === 'pgsql'
             && $this->app['config']['tenancy.separate_by'] === 'schema') {
-                return 'schema';
+            return 'schema';
         }
 
         return 'database';

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -15,7 +15,7 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function __construct(Repository $config, IlluminateDatabaseManager $databaseManager)
     {
-        $this->database = $databaseManager->connection($config['tenancy.database_manager_connections.schema']);
+        $this->database = $databaseManager->connection($config['tenancy.database_manager_connections.pgsql']);
     }
 
     public function createDatabase(string $name): bool

--- a/tests/DatabaseSchemaManagerTest.php
+++ b/tests/DatabaseSchemaManagerTest.php
@@ -4,41 +4,38 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 
-use Stancl\Tenancy\DatabaseManager;
+use Stancl\Tenancy\Tenant;
 
 class DatabaseSchemaManagerTest extends TestCase
 {
     public $autoInitTenancy = false;
 
-    /**
-     * Define environment setup.
-     *
-     * @param  \Illuminate\Foundation\Application  $app
-     * @return void
-     */
     protected function getEnvironmentSetUp($app)
     {
         parent::getEnvironmentSetUp($app);
 
-        $app['config']->set('database.default', 'pgsql');
-        $app['config']->set('tenancy.database.based_on', null);
-        $app['config']->set('tenancy.database.suffix', '');
-        $app['config']->set('tenancy.using_schema_connection', true);
+        $app['config']->set([
+            'database.default' => 'pgsql',
+            'database.connections.pgsql.database' => 'main',
+            'database.connections.pgsql.schema' => 'public',
+            'tenancy.database.based_on' => null,
+            'tenancy.database.suffix' => '',
+            'tenancy.separate_by' => 'schema',
+        ]);
     }
 
     /** @test */
     public function reconnect_method_works()
     {
         $old_connection_name = app(\Illuminate\Database\DatabaseManager::class)->connection()->getName();
-        
+
         tenancy()->init('test.localhost');
 
         app(\Stancl\Tenancy\DatabaseManager::class)->reconnect();
-        
+
         $new_connection_name = app(\Illuminate\Database\DatabaseManager::class)->connection()->getName();
 
-        // $this->assertSame($old_connection_name, $new_connection_name);
-        $this->assertNotEquals('tenant', $new_connection_name);
+        $this->assertSame($old_connection_name, $new_connection_name);
     }
 
     /** @test */
@@ -65,5 +62,80 @@ class DatabaseSchemaManagerTest extends TestCase
         tenancy()->init('schema.localhost');
 
         $this->assertSame($tenant->getDatabaseName(), config('database.connections.' . config('database.default') . '.schema'));
+    }
+
+    /** @test */
+    public function databases_are_separated_using_schema_and_not_database()
+    {
+        tenancy()->create('foo.localhost');
+        tenancy()->init('foo.localhost');
+        $this->assertSame('tenant', config('database.default'));
+        $this->assertSame('main', config('database.connections.tenant.database'));
+
+        $schema1 = config('database.connections.' . config('database.default') . '.schema');
+        $database1 = config('database.connections.' . config('database.default') . '.database');
+
+        tenancy()->create('bar.localhost');
+        tenancy()->init('bar.localhost');
+        $this->assertSame('tenant', config('database.default'));
+        $this->assertSame('main', config('database.connections.tenant.database'));
+
+        $schema2 = config('database.connections.' . config('database.default') . '.schema');
+        $database2 = config('database.connections.' . config('database.default') . '.database');
+
+        $this->assertSame($database1, $database2);
+        $this->assertNotSame($schema1, $schema2);
+    }
+
+    /** @test */
+    public function databases_are_separated()
+    {
+        // copied from DataSeparationTest
+
+        $tenant1 = Tenant::create('tenant1.localhost');
+        $tenant2 = Tenant::create('tenant2.localhost');
+        \Artisan::call('tenants:migrate', [
+            '--tenants' => [$tenant1['id'], $tenant2['id']],
+        ]);
+
+        tenancy()->init('tenant1.localhost');
+        User::create([
+            'name' => 'foo',
+            'email' => 'foo@bar.com',
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+        $this->assertSame('foo', User::first()->name);
+
+        tenancy()->init('tenant2.localhost');
+        $this->assertSame(null, User::first());
+
+        User::create([
+            'name' => 'xyz',
+            'email' => 'xyz@bar.com',
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+
+        $this->assertSame('xyz', User::first()->name);
+        $this->assertSame('xyz@bar.com', User::first()->email);
+
+        tenancy()->init('tenant1.localhost');
+        $this->assertSame('foo', User::first()->name);
+        $this->assertSame('foo@bar.com', User::first()->email);
+
+        $tenant3 = Tenant::create('tenant3.localhost');
+        \Artisan::call('tenants:migrate', [
+            '--tenants' => [$tenant1['id'], $tenant3['id']],
+        ]);
+
+        tenancy()->init('tenant3.localhost');
+        $this->assertSame(null, User::first());
+
+        tenancy()->init('tenant1.localhost');
+        DB::table('users')->where('id', 1)->update(['name' => 'xxx']);
+        $this->assertSame('xxx', User::first()->name);
     }
 }

--- a/tests/DatabaseSchemaManagerTest.php
+++ b/tests/DatabaseSchemaManagerTest.php
@@ -42,7 +42,7 @@ class DatabaseSchemaManagerTest extends TestCase
     public function the_default_db_is_used_when_based_on_is_null()
     {
         config(['database.default' => 'pgsql']);
-        
+
         $this->assertSame('pgsql', config('database.default'));
         config([
             'database.connections.pgsql.foo' => 'bar',

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -79,7 +79,7 @@ class TenantDatabaseManagerTest extends TestCase
             ['mysql', MySQLDatabaseManager::class],
             ['sqlite', SQLiteDatabaseManager::class],
             ['pgsql', PostgreSQLDatabaseManager::class],
-            ['schema', PostgreSQLSchemaManager::class]
+            ['pgsql', PostgreSQLSchemaManager::class]
         ];
     }
 

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -10,8 +10,8 @@ use Stancl\Tenancy\Jobs\QueuedTenantDatabaseDeleter;
 use Stancl\Tenancy\Tenant;
 use Stancl\Tenancy\TenantDatabaseManagers\MySQLDatabaseManager;
 use Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager;
-use Stancl\Tenancy\TenantDatabaseManagers\SQLiteDatabaseManager;
 use Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLSchemaManager;
+use Stancl\Tenancy\TenantDatabaseManagers\SQLiteDatabaseManager;
 
 class TenantDatabaseManagerTest extends TestCase
 {
@@ -79,7 +79,7 @@ class TenantDatabaseManagerTest extends TestCase
             ['mysql', MySQLDatabaseManager::class],
             ['sqlite', SQLiteDatabaseManager::class],
             ['pgsql', PostgreSQLDatabaseManager::class],
-            ['pgsql', PostgreSQLSchemaManager::class]
+            ['pgsql', PostgreSQLSchemaManager::class],
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -24,11 +24,12 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         Redis::connection('tenancy')->flushdb();
         Redis::connection('cache')->flushdb();
 
+        $originalConnection = config('database.default');
         $this->loadMigrationsFrom([
             '--path' => realpath(__DIR__ . '/../assets/migrations'),
             '--database' => 'central',
         ]);
-        config(['database.default' => 'sqlite']); // fix issue caused by loadMigrationsFrom
+        config(['database.default' => $originalConnection]); // fix issue caused by loadMigrationsFrom
 
         if ($this->autoCreateTenant) {
             $this->createTenant();


### PR DESCRIPTION
- Instead of a `schema` key in the `database_managers` array, I use a commented line with `pgsql`. This way all the keys in that array represent keys in the `database.connections` config, so the `DatabaseManager` can be simplified
- I went with `separate_by` instead of `using_schema_connection` so that we can add more options in the future (e.g. if we somehow support single-DB tenancy)
- Fixed TestCase so that the `$this->assertSame($old_connection_name, $new_connection_name);` assertion works for schema pgsql
- Added two more test cases to ensure that data is separated correctly when using schema mode

This is WIP because I'm getting an error for the `DatabaseSchemaManagerTest::databases_are_separated` test: 

```
1) Stancl\Tenancy\Tests\DatabaseSchemaManagerTest::databases_are_separated
Illuminate\Database\QueryException: SQLSTATE[3F000]: Invalid schema name: 7 ERROR:  no schema has been selected to create in at character 14 (SQL: create table "migrations" ("id" serial primary key not null, "migration" varchar(255) not null, "batch" integer not null))
```

This is caused by running `Artisan::call('tenants:migrate')` when using the schema mode. Do you know what could be the problem?